### PR TITLE
OpenVX OCL&HIP GPU backend - vxCreateImageFromChannel bug fix

### DIFF
--- a/.jenkins/common.groovy
+++ b/.jenkins/common.groovy
@@ -67,8 +67,8 @@ def runTestCommand (platform, project) {
 
     if (platform.jenkinsLabel.contains('centos') || platform.jenkinsLabel.contains('ubuntu')) {
         conformaceCPU = 'AGO_DEFAULT_TARGET=CPU LD_LIBRARY_PATH=./lib ./bin/vx_test_conformance | tee OpenVX-CPU-Conformance-log.md'
-        conformaceOpenCL = 'AGO_DEFAULT_TARGET=GPU LD_LIBRARY_PATH=./lib ./bin/vx_test_conformance --filter=-HarrisCorners.*:-*.ReplicateNode:-*.ImageContainmentRelationship:-*.OnRandomAndNatural:-*.vxWeightedAverage:-vxCanny.*:-*.MapRandomRemap:*.* | tee OpenVX-GPU-OPENCL-Conformance-log.md'
-        conformaceHIP = 'AGO_DEFAULT_TARGET=GPU LD_LIBRARY_PATH=./lib ./bin/vx_test_conformance --filter=-*.VirtualArray:-HarrisCorners.*:-vxCanny.*:-*.ReplicateNode:-*.ImageContainmentRelationship:-*.MapRandomRemap:-*.OnRandomAndNatural:*.* | tee OpenVX-GPU-HIP-Conformance-log.md'
+        conformaceOpenCL = 'AGO_DEFAULT_TARGET=GPU LD_LIBRARY_PATH=./lib ./bin/vx_test_conformance --filter=-HarrisCorners.*:-vxCanny.*:-*.ReplicateNode:-*.ImageContainmentRelationship:-*.MapRandomRemap:-*.OnRandomAndNatural:*.* | tee OpenVX-GPU-OPENCL-Conformance-log.md'
+        conformaceHIP = 'AGO_DEFAULT_TARGET=GPU LD_LIBRARY_PATH=./lib ./bin/vx_test_conformance --filter=-HarrisCorners.*:-vxCanny.*:-*.ReplicateNode:-*.ImageContainmentRelationship:-*.MapRandomRemap:-*.OnRandomAndNatural:*.* | tee OpenVX-GPU-HIP-Conformance-log.md'
         moveFiles = 'mv *.md ../../'
     }
 

--- a/amd_openvx/cmake/FindOpenCL.cmake
+++ b/amd_openvx/cmake/FindOpenCL.cmake
@@ -106,7 +106,7 @@ else()
 
     if(OpenCL_FOUND)
         execute_process(
-            COMMAND bash -c "nm -gDC ${OPENCL_LIBRARIES} | grep OPENCL_2.2"
+            COMMAND bash -c "nm -gDC ${OpenCL_LIBRARIES} | grep OPENCL_2.2"
             OUTPUT_VARIABLE outVar
         )
         if(NOT ${outVar} STREQUAL "")

--- a/amd_openvx/openvx/ago/ago_interface.cpp
+++ b/amd_openvx/openvx/ago/ago_interface.cpp
@@ -2248,7 +2248,7 @@ int agoExecuteGraph(AgoGraph * graph)
                         (node->parameters[i].direction == VX_INPUT || node->parameters[i].direction == VX_BIDIRECTIONAL))
                     {
                         auto dataToSync = (data->ref.type == VX_TYPE_IMAGE && data->u.img.isROI) ? data->u.img.roiMasterImage : data;
-                        if ((AGO_BUFFER_SYNC_FLAG_DIRTY_BY_NODE | AGO_BUFFER_SYNC_FLAG_DIRTY_BY_COMMIT) &&
+                        if (dataToSync->buffer_sync_flags & (AGO_BUFFER_SYNC_FLAG_DIRTY_BY_NODE | AGO_BUFFER_SYNC_FLAG_DIRTY_BY_COMMIT) &&
                             dataToSync->opencl_buffer && !(dataToSync->buffer_sync_flags & AGO_BUFFER_SYNC_FLAG_DIRTY_SYNCHED))
                         {
                             status = agoDirective((vx_reference)dataToSync, VX_DIRECTIVE_AMD_COPY_TO_OPENCL);

--- a/amd_openvx/openvx/ago/ago_kernel_api.cpp
+++ b/amd_openvx/openvx/ago/ago_kernel_api.cpp
@@ -1867,6 +1867,8 @@ int ovxKernel_HarrisCorners(AgoNode * node, AgoKernelCommand cmd)
     // INFO: use VX_KERNEL_AMD_HARRIS_SOBEL_* kernels to compute Gx^2, Gx*Gy, Gy^2
     //       use VX_KERNEL_AMD_HARRIS_SCORE_* kernels to compute Vc
     //       use VX_KERNEL_AMD_HARRIS_MERGE_SORT_AND_PICK_XY_HVC kernel for final step
+    //       disable buffer merging for HarrisCorners
+    agoSetEnvironmentVariable("AGO_BUFFER_MERGE_FLAGS", "1");
     vx_status status = AGO_ERROR_KERNEL_NOT_IMPLEMENTED;
     if (cmd == ago_kernel_cmd_execute) {
         // TBD: not implemented yet

--- a/amd_openvx/openvx/ago/ago_kernel_api.cpp
+++ b/amd_openvx/openvx/ago/ago_kernel_api.cpp
@@ -872,7 +872,7 @@ int ovxKernel_Threshold(AgoNode * node, AgoKernelCommand cmd)
             return VX_ERROR_INVALID_FORMAT;
         else if (!width || !height)
             return VX_ERROR_INVALID_DIMENSION;
-        if (node->paramList[1]->u.thr.data_type != VX_TYPE_UINT8)
+        if (node->paramList[1]->u.thr.data_type != VX_TYPE_UINT8 && node->paramList[1]->u.thr.data_type != VX_TYPE_INT16)
             return VX_ERROR_INVALID_TYPE;
         // set output image sizes are same as input image size
         vx_meta_format meta;
@@ -3729,7 +3729,7 @@ int agoKernel_Threshold_U8_S16_Binary(AgoNode * node, AgoKernelCommand cmd)
     }
     else if (cmd == ago_kernel_cmd_validate) {
         if (!(status = ValidateArguments_Img_1OUT_1IN(node, VX_DF_IMAGE_U8, VX_DF_IMAGE_S16))) {
-            if (node->paramList[2]->u.thr.thresh_type != VX_THRESHOLD_TYPE_BINARY || node->paramList[2]->u.thr.data_type != VX_TYPE_UINT8)
+            if (node->paramList[2]->u.thr.thresh_type != VX_THRESHOLD_TYPE_BINARY || (node->paramList[2]->u.thr.data_type != VX_TYPE_UINT8 && node->paramList[2]->u.thr.data_type != VX_TYPE_INT16))
                 return VX_ERROR_INVALID_TYPE;
         }
     }
@@ -3803,7 +3803,7 @@ int agoKernel_Threshold_U8_S16_Range(AgoNode * node, AgoKernelCommand cmd)
     }
     else if (cmd == ago_kernel_cmd_validate) {
         if (!(status = ValidateArguments_Img_1OUT_1IN(node, VX_DF_IMAGE_U8, VX_DF_IMAGE_S16))) {
-            if (node->paramList[2]->u.thr.thresh_type != VX_THRESHOLD_TYPE_RANGE || node->paramList[2]->u.thr.data_type != VX_TYPE_UINT8)
+            if (node->paramList[2]->u.thr.thresh_type != VX_THRESHOLD_TYPE_RANGE || (node->paramList[2]->u.thr.data_type != VX_TYPE_UINT8 && node->paramList[2]->u.thr.data_type != VX_TYPE_INT16))
                 return VX_ERROR_INVALID_TYPE;
         }
     }
@@ -18082,7 +18082,7 @@ int agoKernel_CannySuppThreshold_U8XY_U16_7x7(AgoNode * node, AgoKernelCommand c
             node->hip_stream0, oImg->u.img.width, oImg->u.img.height, oImg->hip_memory + oImg->gpu_buffer_offset, oImg->u.img.stride_in_bytes,
             (vx_uint16 *) (iImg->hip_memory + iImg->gpu_buffer_offset), iImg->u.img.stride_in_bytes,
             oStack->hip_memory, oStack->gpu_buffer_offset, oStack->u.cannystack.count,
-            iThr->u.thr.threshold_lower.U1, iThr->u.thr.threshold_upper.U1)) {
+            iThr->u.thr.threshold_lower.U1 / 4, iThr->u.thr.threshold_upper.U1 / 4)) {
             status = VX_FAILURE;
         }
     }

--- a/amd_openvx/openvx/ago/ago_kernel_list.cpp
+++ b/amd_openvx/openvx/ago/ago_kernel_list.cpp
@@ -537,6 +537,7 @@ int agoPublishKernels(AgoContext * acontext)
 		kernel->kernOpInfo = ago_kernel_list[i].kernOpInfo;
 		kernel->finalized = true;
 		kernel->ref.internal_count = 1;
+		kernel->user_kernel = false;
 		strcpy(kernel->name, ago_kernel_list[i].name);
 		memcpy(kernel->argConfig, ago_kernel_list[i].argConfig, sizeof(kernel->argConfig));
 		kernel->argCount = 0;

--- a/amd_openvx/openvx/ago/ago_platform.cpp
+++ b/amd_openvx/openvx/ago/ago_platform.cpp
@@ -85,6 +85,15 @@ bool agoGetEnvironmentVariable(const char * name, char * value, size_t valueSize
 #endif
 }
 
+bool agoSetEnvironmentVariable(const char * name, const char * value)
+{
+#if _WIN32
+    return SetEnvironmentVariableA(name, value);
+#else
+    return !(setenv(name, value, 1));
+#endif
+}
+
 ago_module agoOpenModule(const char * libFileName)
 {
 #if _WIN32

--- a/amd_openvx/openvx/ago/ago_platform.h
+++ b/amd_openvx/openvx/ago/ago_platform.h
@@ -133,6 +133,7 @@ void       agoControlFpReset(uint32_t state);
 int64_t    agoGetClockCounter();
 int64_t    agoGetClockFrequency();
 bool       agoGetEnvironmentVariable(const char * name, char * value, size_t valueSize); // returns true if success
+bool       agoSetEnvironmentVariable(const char * name, const char * value); // returns true if success
 ago_module agoOpenModule(const char * libFileName);
 void *     agoGetFunctionAddress(ago_module module, const char * functionName);
 void       agoCloseModule(ago_module module);

--- a/amd_openvx/openvx/api/vx_api.cpp
+++ b/amd_openvx/openvx/api/vx_api.cpp
@@ -943,7 +943,7 @@ VX_API_ENTRY vx_image VX_API_CALL vxCreateImageFromHandle(vx_context context, vx
                     data->buffer = (vx_uint8 *)(ptrs ? ptrs[0] : nullptr);
                     data->u.img.stride_in_bytes = addrs[0].stride_y;
                     data->gpu_buffer_offset = 0;
-#if ENABLE_OPENCL
+#if (ENABLE_OPENCL || ENABLE_HIP)
                     data->buffer_sync_flags &= ~AGO_BUFFER_SYNC_FLAG_DIRTY_MASK;
                     data->buffer_sync_flags |= AGO_BUFFER_SYNC_FLAG_DIRTY_BY_COMMIT;
 #endif

--- a/amd_openvx/openvx/api/vx_api.cpp
+++ b/amd_openvx/openvx/api/vx_api.cpp
@@ -932,6 +932,10 @@ VX_API_ENTRY vx_image VX_API_CALL vxCreateImageFromHandle(vx_context context, vx
                         data->children[i]->buffer = (vx_uint8 *)(ptrs ? ptrs[i] : nullptr);
                         data->children[i]->u.img.stride_in_bytes = addrs[i].stride_y;
                         data->children[i]->gpu_buffer_offset = 0;
+#if ENABLE_OPENCL
+                    data->children[i]->buffer_sync_flags &= ~AGO_BUFFER_SYNC_FLAG_DIRTY_MASK;
+                    data->children[i]->buffer_sync_flags |= AGO_BUFFER_SYNC_FLAG_DIRTY_BY_COMMIT;
+#endif
                     }
                 }
                 else {
@@ -939,6 +943,10 @@ VX_API_ENTRY vx_image VX_API_CALL vxCreateImageFromHandle(vx_context context, vx
                     data->buffer = (vx_uint8 *)(ptrs ? ptrs[0] : nullptr);
                     data->u.img.stride_in_bytes = addrs[0].stride_y;
                     data->gpu_buffer_offset = 0;
+#if ENABLE_OPENCL
+                    data->buffer_sync_flags &= ~AGO_BUFFER_SYNC_FLAG_DIRTY_MASK;
+                    data->buffer_sync_flags |= AGO_BUFFER_SYNC_FLAG_DIRTY_BY_COMMIT;
+#endif
                 }
                 data->u.img.mem_handle = vx_false_e;
             }

--- a/amd_openvx/openvx/api/vx_api.cpp
+++ b/amd_openvx/openvx/api/vx_api.cpp
@@ -932,7 +932,7 @@ VX_API_ENTRY vx_image VX_API_CALL vxCreateImageFromHandle(vx_context context, vx
                         data->children[i]->buffer = (vx_uint8 *)(ptrs ? ptrs[i] : nullptr);
                         data->children[i]->u.img.stride_in_bytes = addrs[i].stride_y;
                         data->children[i]->gpu_buffer_offset = 0;
-#if ENABLE_OPENCL
+#if (ENABLE_OPENCL || ENABLE_HIP)
                     data->children[i]->buffer_sync_flags &= ~AGO_BUFFER_SYNC_FLAG_DIRTY_MASK;
                     data->children[i]->buffer_sync_flags |= AGO_BUFFER_SYNC_FLAG_DIRTY_BY_COMMIT;
 #endif

--- a/amd_openvx/openvx/api/vx_api.cpp
+++ b/amd_openvx/openvx/api/vx_api.cpp
@@ -5688,7 +5688,7 @@ VX_API_ENTRY vx_threshold VX_API_CALL vxCreateThresholdForImage(vx_context conte
                     agoGenerateDataName(context, "thr", data->name);
                     agoAddData(&context->dataList, data);
 
-                    switch (output_format)
+                    switch (input_format)
                     {
                         case VX_DF_IMAGE_RGB:
                         {


### PR DESCRIPTION
This PR fixes vxCreateImageFromChannel.ChannelFromHandel bug.
While fixing this bug:
OCL: it led to a bug with LUT for type S16 when copying data to opencl buffers since this wasn't part of the code. I have added it to the PR
HIP: Led to a bug with convolve while copying from host to device. Fixed it

@hansely Please sync with TOT to see only my changes
@asalmanp Can you please review the changes